### PR TITLE
Fix appdata <extends> Nautilus ID

### DIFF
--- a/appdata-use-Nautilus-ID-without-.desktop.patch
+++ b/appdata-use-Nautilus-ID-without-.desktop.patch
@@ -1,0 +1,25 @@
+From 901c514849ff20ba31601a329b644055c210419c Mon Sep 17 00:00:00 2001
+From: Federico Bruni <fede@inventati.org>
+Date: Mon, 14 Feb 2022 15:34:45 +0100
+Subject: [PATCH] appdata: use Nautilus ID without .desktop
+
+---
+ data/org.gnome.NautilusPreviewer.appdata.xml.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/data/org.gnome.NautilusPreviewer.appdata.xml.in b/data/org.gnome.NautilusPreviewer.appdata.xml.in
+index 726c329..bfec09e 100644
+--- a/data/org.gnome.NautilusPreviewer.appdata.xml.in
++++ b/data/org.gnome.NautilusPreviewer.appdata.xml.in
+@@ -3,7 +3,7 @@
+ -->
+ <component type="addon">
+   <id>org.gnome.NautilusPreviewer</id>
+-  <extends>org.gnome.Nautilus.desktop</extends>
++  <extends>org.gnome.Nautilus</extends>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0+</project_license>
+   <name>Sushi</name>
+-- 
+2.35.1
+

--- a/org.gnome.NautilusPreviewer.json
+++ b/org.gnome.NautilusPreviewer.json
@@ -104,6 +104,10 @@
                     "type": "archive",
                     "url": "https://download.gnome.org/sources/sushi/41/sushi-41.0.tar.xz",
                     "sha256": "9b7525690ce436624efa0a605773493432cd0ef6b8f464982e8b844eda9898ee"
+                },
+                {
+                    "type": "patch",
+                    "path": "appdata-use-Nautilus-ID-without-.desktop.patch"
                 }
             ]
         }


### PR DESCRIPTION
Sushi page on flathub.org is not found:
https://flathub.org/apps/details/org.gnome.NautilusPreviewer

It may be caused by an error in the appdata file.