### PR TITLE
runtime: Update to 50

### DIFF
--- a/org.gnome.NautilusPreviewer.json
+++ b/org.gnome.NautilusPreviewer.json
@@ -123,8 +123,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://download.gnome.org/sources/sushi/46/sushi-46.0.tar.xz",
-                    "sha256": "96085baaa430ab2142c606aab5c47e2fbb2fd3eb70a352137e65c59a58a0f2c6",
+                    "url": "https://download.gnome.org/sources/sushi/50/sushi-50.rc.1.tar.xz",
+                    "sha256": "97a79f9c7e08b0b176026ed4c7a0435f0612c4c10da33d47e2bafab9c6292263",
                     "x-checker-data": {
                         "type": "gnome",
                         "is-important": true,


### PR DESCRIPTION
Experimenting the upgrade to sushi 50 (latest is sushi-50.rc.1 at the moment). Just trying to have the dependencies sorted out for when 50 becomes stable.